### PR TITLE
Add Django skeleton

### DIFF
--- a/simulator/manage.py
+++ b/simulator/manage.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+import os
+import sys
+
+if __name__ == '__main__':
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'simulator.settings')
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)

--- a/simulator/simulator/settings.py
+++ b/simulator/simulator/settings.py
@@ -1,0 +1,63 @@
+import os
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SECRET_KEY = 'replace-me'
+DEBUG = True
+ALLOWED_HOSTS = []
+
+INSTALLED_APPS = [
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'web',
+]
+
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
+
+ROOT_URLCONF = 'simulator.urls'
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [os.path.join(BASE_DIR, 'templates')],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
+WSGI_APPLICATION = 'simulator.wsgi.application'
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    }
+}
+
+AUTH_PASSWORD_VALIDATORS = []
+
+LANGUAGE_CODE = 'en-us'
+TIME_ZONE = 'UTC'
+USE_I18N = True
+USE_TZ = True
+
+STATIC_URL = '/static/'
+STATICFILES_DIRS = [os.path.join(BASE_DIR, 'assets')]

--- a/simulator/simulator/urls.py
+++ b/simulator/simulator/urls.py
@@ -1,0 +1,7 @@
+from django.contrib import admin
+from django.urls import path, include
+
+urlpatterns = [
+    path('admin/', admin.site.urls),
+    path('', include('web.urls')),
+]

--- a/simulator/simulator/wsgi.py
+++ b/simulator/simulator/wsgi.py
@@ -1,0 +1,5 @@
+import os
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'simulator.settings')
+application = get_wsgi_application()

--- a/simulator/templates/Index.html
+++ b/simulator/templates/Index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Simulador de subsidios y créditos hipotecarios para vivienda en Chile">
+    <title>Simulador de Subsidios para Vivienda</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body>
+    <header>
+        <h1>Simulador de Subsidios para Vivienda</h1>
+        <p>¡Bienvenido! Selecciona una opción para comenzar a simular tu camino hacia una vivienda propia.</p>
+    </header>
+    <main>
+        <div class="subsidy-options">
+            <article class="subsidy-card">
+                <a href="pages/percentile.html">
+                    <h2>Calcula tu percentil</h2>
+                    <p>Calcula tu percentil de ingreso y descubre a qué subsidios de compras de casas (DS49 o DS1) puedes optar.</p>
+                </a>
+            </article>
+            <article class="subsidy-card">
+                <a href="pages/subsidies.html">
+                    <h2>Simulador de Subsidios</h2>
+                    <p>Simula el crédito hipotecario con diferentes subsidios habitacionales.</p>
+                </a>
+            </article>
+            <article class="subsidy-card">
+                <a href="pages/no-subsidy.html">
+                    <h2>Compra sin Subsidio</h2>
+                    <p>Simula un crédito hipotecario sin aplicar subsidios.</p>
+                </a>
+            </article>
+            <article class="subsidy-card">
+                <a href="pages/max-value.html">
+                    <h2>Valor Máximo de Casa</h2>
+                    <p>Calcula el valor máximo de una vivienda según tu sueldo.</p>
+                </a>
+            </article>
+            <article class="subsidy-card">
+                <a href="pages/subsidy-assistant.html">
+                    <h2>Asistente de Subsidios</h2>
+                    <p>Responde preguntas para descubrir a qué subsidios puedes optar.</p>
+                </a>
+            </article>
+        </div>
+        <h5 style="text-align: center; display: block;">Aviso: La tasa de crédito anual está por defecto en un 5.1%, pero puede cambiarlo a una tasa mas actual según su banco. Favor de tenerlo en consideración para una simulación mas adecuada a su situación económica.</a>
+    </main>
+    <footer>
+        <p>© 2025 Simulador de Subsidios para Vivienda</p>
+    </footer>
+</body>
+</html>

--- a/simulator/templates/pages/max-value.html
+++ b/simulator/templates/pages/max-value.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Calcula el valor máximo de una vivienda según tu sueldo">
+    <title>Valor Máximo de Casa - Simulador</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../assets/css/max-value.css">
+</head>
+<body>
+    <header>
+        <h1>Valor Máximo de Casa</h1>
+        <p>Selecciona una opción para calcular el valor máximo de la vivienda que puedes comprar</p>
+    </header>
+    <main>
+        <div class="subsidy-options">
+            <article class="subsidy-card">
+                <a href="max-value/ds1t1.html">
+                    <h2>Subsidio DS1 Tramo 1</h2>
+                    <p>Para personas en el 60% más vulnerable.</p>
+                </a>
+            </article>
+            <article class="subsidy-card">
+                <a href="max-value/ds1t2.html">
+                    <h2>Subsidio DS1 Tramo 2</h2>
+                    <p>Compra de viviendas hasta 1.600 UF (hasta 70% de vulnerabilidad).</p>
+                </a>
+            </article>
+            <article class="subsidy-card">
+                <a href="max-value/ds1t3.html">
+                    <h2>Subsidio DS1 Tramo 3</h2>
+                    <p>Compra de viviendas hasta 2.200 UF.</p>
+                </a>
+            </article>
+            <article class="subsidy-card">
+                <a href="max-value/no-subsidy.html">
+                    <h2>Sin Subsidio</h2>
+                    <p>Calcula el valor máximo de una vivienda sin aplicar subsidios.</p>
+                </a>
+            </article>
+        </div>
+    </main>
+    <footer>
+        <button onclick="window.location.href='../index.html'">Volver al inicio</button>
+        <p>© 2025 Simulador de Subsidios para Vivienda</p>
+    </footer>
+</body>
+</html>

--- a/simulator/templates/pages/max-value/ds1t1.html
+++ b/simulator/templates/pages/max-value/ds1t1.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Calcula el valor máximo de una vivienda con Subsidio DS1 Tramo 1">
+    <title>Valor Máximo - Subsidio DS1 Tramo 1</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/max-value.css">
+</head>
+<body>
+    <header>
+        <h1>Valor Máximo - Subsidio DS1 Tramo 1</h1>
+        <p>Ingresa los datos para calcular el valor máximo de la vivienda</p>
+    </header>
+    <main>
+        <section class="form-container">
+            <form id="max-value-form">
+                <div class="form-group">
+                    <label for="income-clp">Sueldo mensual (CLP):</label>
+                    <input type="number" id="income-clp" min="0" step="1000" onchange="convertToUF()" required>
+                </div>
+                <div class="form-group">
+                    <label for="income-uf">Sueldo mensual (UF):</label>
+                    <input type="number" id="income-uf" step="0.01" readonly>
+                </div>
+                <div class="form-group">
+                    <label for="is-young-single">¿Eres joven soltero (menor de 35 años)?</label>
+                    <input type="checkbox" id="is-young-single">
+                </div>
+                <div class="form-group">
+                    <label for="savings-uf">Ahorro en UF (mínimo 30 UF):</label>
+                    <input type="number" id="savings-uf" min="30" step="1" required>
+                </div>
+                <div class="form-group">
+                    <label for="location">Ubicación:</label>
+                    <select id="location" required>
+                        <option value="none">Zona Regular</option>
+                        <option value="north">Extremo Norte</option>
+                        <option value="south">Extremo Sur</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="uf-value">Valor actual de la UF (CLP):</label>
+                    <input type="number" id="uf-value" step="0.01" readonly>
+                </div>
+                <div class="form-group">
+                    <label for="interest-rate">Tasa de interés anual (%):</label>
+                    <input type="number" id="interest-rate" value="5.1" step="0.01" required>
+                </div>
+                <div class="form-group">
+                    <label for="loan-term">Plazo del crédito (años):</label>
+                    <select id="loan-term" required>
+                        <option value="10">10 años</option>
+                        <option value="15">15 años</option>
+                        <option value="20">20 años</option>
+                        <option value="25" selected>25 años</option>
+                        <option value="30">30 años</option>
+                    </select>
+                </div>
+                <button type="submit">Calcular valor máximo</button>
+            </form>
+        </section>
+        <section id="results" class="results-container"></section>
+    </main>
+    <footer>
+        <button onclick="window.location.href='../max-value.html'">Volver</button>
+        <p>© 2025 Simulador de Subsidios para Vivienda</p>
+    </footer>
+    <script src="../../assets/js/max-value/ds1t1.js"></script>
+</body>
+</html>

--- a/simulator/templates/pages/max-value/ds1t2.html
+++ b/simulator/templates/pages/max-value/ds1t2.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Calcula el valor máximo de una vivienda con Subsidio DS1 Tramo 2">
+    <title>Valor Máximo - Subsidio DS1 Tramo 2</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/max-value.css">
+</head>
+<body>
+    <header>
+        <h1>Valor Máximo - Subsidio DS1 Tramo 2</h1>
+        <p>Ingresa los datos para calcular el valor máximo de la vivienda</p>
+    </header>
+    <main>
+        <section class="form-container">
+            <form id="max-value-form">
+                <div class="form-group">
+                    <label for="income-clp">Sueldo mensual (CLP):</label>
+                    <input type="number" id="income-clp" min="0" step="1000" onchange="convertToUF()" required>
+                </div>
+                <div class="form-group">
+                    <label for="income-uf">Sueldo mensual (UF):</label>
+                    <input type="number" id="income-uf" step="0.01" readonly>
+                </div>
+                <div class="form-group">
+                    <label for="is-young-single">¿Eres joven soltero (menor de 35 años)?</label>
+                    <input type="checkbox" id="is-young-single">
+                </div>
+                <div class="form-group">
+                    <label for="savings-uf">Ahorro en UF (mínimo 40 UF):</label>
+                    <input type="number" id="savings-uf" min="40" step="1" onchange="adjustMaxPropertyValue()" required>
+                </div>
+                <div class="form-group">
+                    <label for="is-new-home">¿La vivienda es nueva?</label>
+                    <input type="checkbox" id="is-new-home" onchange="adjustMaxPropertyValue()">
+                </div>
+                <div class="form-group">
+                    <label for="location">Ubicación:</label>
+                    <select id="location" onchange="adjustMaxPropertyValue()" required>
+                        <option value="none">Zona Regular</option>
+                        <option value="north">Extremo Norte</option>
+                        <option value="south">Extremo Sur</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="uf-value">Valor actual de la UF (CLP):</label>
+                    <input type="number" id="uf-value" step="0.01" readonly>
+                </div>
+                <div class="form-group">
+                    <label for="interest-rate">Tasa de interés anual (%):</label>
+                    <input type="number" id="interest-rate" value="5.1" step="0.01" required>
+                </div>
+                <div class="form-group">
+                    <label for="loan-term">Plazo del crédito (años):</label>
+                    <select id="loan-term" required>
+                        <option value="10">10 años</option>
+                        <option value="15">15 años</option>
+                        <option value="20">20 años</option>
+                        <option value="25" selected>25 años</option>
+                        <option value="30">30 años</option>
+                    </select>
+                </div>
+                <button type="submit">Calcular valor máximo</button>
+            </form>
+        </section>
+        <section id="results" class="results-container"></section>
+    </main>
+    <footer>
+        <button onclick="window.location.href='../max-value.html'">Volver</button>
+        <p>© 2025 Simulador de Subsidios para Vivienda</p>
+    </footer>
+    <script src="../../assets/js/max-value/ds1t2.js"></script>
+</body>
+</html>

--- a/simulator/templates/pages/max-value/ds1t3.html
+++ b/simulator/templates/pages/max-value/ds1t3.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Calcula el valor máximo de una vivienda con Subsidio DS1 Tramo 3">
+    <title>Valor Máximo - Subsidio DS1 Tramo 3</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/../assets/css/max-value.css">
+</head>
+<body>
+    <header>
+        <h1>Valor Máximo - Subsidio DS1 Tramo 3</h1>
+        <p>Ingresa los datos para calcular el valor máximo de la vivienda</p>
+    </header>
+    <main>
+        <section class="form-container">
+            <form id="max-value-form">
+                <div class="form-group">
+                    <label for="income-clp">Sueldo mensual (CLP):</label>
+                    <input type="number" id="income-clp" min="0" step="1000" onchange="convertToUF()" required>
+                </div>
+                <div class="form-group">
+                    <label for="income-uf">Sueldo mensual (UF):</label>
+                    <input type="number" id="income-uf" step="0.01" readonly>
+                </div>
+                <div class="form-group">
+                    <label for="is-young-single">¿Eres joven soltero (menor de 35 años)?</label>
+                    <input type="checkbox" id="is-young-single">
+                </div>
+                <div class="form-group">
+                    <label for="savings-uf">Ahorro en UF (mínimo 80 UF):</label>
+                    <input type="number" id="savings-uf" min="80" step="1" onchange="adjustMaxPropertyValue()" required>
+                </div>
+                <div class="form-group">
+                    <label for="is-new-home">¿La vivienda es nueva?</label>
+                    <input type="checkbox" id="is-new-home" onchange="adjustMaxPropertyValue()">
+                </div>
+                <div class="form-group">
+                    <label for="location">Ubicación:</label>
+                    <select id="location" onchange="adjustMaxPropertyValue()" required>
+                        <option value="none">Zona Regular</option>
+                        <option value="north">Extremo Norte</option>
+                        <option value="south">Extremo Sur</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="uf-value">Valor actual de la UF (CLP):</label>
+                    <input type="number" id="uf-value" step="0.01" readonly>
+                </div>
+                <div class="form-group">
+                    <label for="interest-rate">Tasa de interés anual (%):</label>
+                    <input type="number" id="interest-rate" value="5.1" step="0.01" required>
+                </div>
+                <div class="form-group">
+                    <label for="loan-term">Plazo del crédito (años):</label>
+                    <select id="loan-term" required>
+                        <option value="10">10 años</option>
+                        <option value="15">15 años</option>
+                        <option value="20">20 años</option>
+                        <option value="25" selected>25 años</option>
+                        <option value="30">30 años</option>
+                    </select>
+                </div>
+                <button type="submit">Calcular valor máximo</button>
+            </form>
+        </section>
+        <section id="results" class="results-container"></section>
+    </main>
+    <footer>
+        <button onclick="window.location.href='../max-value.html'">Volver</button>
+        <p>© 2025 Simulador de Subsidios para Vivienda</p>
+    </footer>
+    <script src="../../assets/js/max-value/ds1t3.js"></script>
+</body>
+</html>

--- a/simulator/templates/pages/max-value/no-subsidy.html
+++ b/simulator/templates/pages/max-value/no-subsidy.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Calcula el valor máximo de una vivienda sin subsidio">
+    <title>Valor Máximo - Sin Subsidio</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/../assets/css/max-value.css">
+</head>
+<body>
+    <header>
+        <h1>Valor Máximo - Sin Subsidio</h1>
+        <p>Ingresa los datos para calcular el valor máximo de la vivienda</p>
+    </header>
+    <main>
+        <section class="form-container">
+            <form id="max-value-form">
+                <div class="form-group">
+                    <label for="income-clp">Sueldo mensual (CLP):</label>
+                    <input type="number" id="income-clp" min="0" step="1000" onchange="convertToUF()" required>
+                </div>
+                <div class="form-group">
+                    <label for="income-uf">Sueldo mensual (UF):</label>
+                    <input type="number" id="income-uf" step="0.01" readonly>
+                </div>
+                <div class="form-group">
+                    <label for="is-young-single">¿Eres joven soltero (menor de 35 años)?</label>
+                    <input type="checkbox" id="is-young-single">
+                </div>
+                <div class="form-group">
+                    <label for="down-payment">Pie:</label>
+                    <select id="down-payment-type" onchange="adjustDownPaymentOptions()">
+                        <option value="percentage">Porcentaje</option>
+                        <option value="uf">UF</option>
+                    </select>
+                    <input type="number" id="down-payment" min="10" max="50" step="0.01" required>
+                </div>
+                <div class="form-group">
+                    <label for="uf-value">Valor actual de la UF (CLP):</label>
+                    <input type="number" id="uf-value" step="0.01" readonly>
+                </div>
+                <div class="form-group">
+                    <label for="interest-rate">Tasa de interés anual (%):</label>
+                    <input type="number" id="interest-rate" value="5.1" step="0.01" required>
+                </div>
+                <div class="form-group">
+                    <label for="loan-term">Plazo del crédito (años):</label>
+                    <select id="loan-term" required>
+                        <option value="10">10 años</option>
+                        <option value="15">15 años</option>
+                        <option value="20">20 años</option>
+                        <option value="25" selected>25 años</option>
+                        <option value="30">30 años</option>
+                    </select>
+                </div>
+                <button type="submit">Calcular valor máximo</button>
+            </form>
+        </section>
+        <section id="results" class="results-container"></section>
+    </main>
+    <footer>
+        <button onclick="window.location.href='../max-value.html'">Volver</button>
+        <p>© 2025 Simulador de Subsidios para Vivienda</p>
+    </footer>
+    <script src="../../assets/js/max-value/no-subsidy.js"></script>
+</body>
+</html>

--- a/simulator/templates/pages/no-subsidy.html
+++ b/simulator/templates/pages/no-subsidy.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Simula un crédito hipotecario para comprar una vivienda sin subsidio">
+    <title>Compra sin Subsidio - Simulador</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../assets/css/no-subsidy.css">
+</head>
+<body>
+    <header>
+        <h1>Compra sin Subsidio</h1>
+        <p>Ingresa los datos para simular tu crédito hipotecario</p>
+    </header>
+    <main>
+        <section class="form-container">
+            <form id="simulacion-form">
+                <div class="form-group">
+                    <label for="property-value-clp">Valor de la vivienda (CLP):</label>
+                    <input type="number" id="property-value-clp" min="0" step="1000" onchange="convertToUF()">
+                </div>
+                <div class="form-group">
+                    <label for="property-value">Valor de la vivienda (UF):</label>
+                    <input type="number" id="property-value" min="1" required step="0.01">
+                </div>
+                <div class="form-group">
+                    <label for="down-payment">Pie:</label>
+                    <select id="down-payment-type" onchange="adjustDownPaymentOptions()">
+                        <option value="percentage">Porcentaje</option>
+                        <option value="uf">UF</option>
+                    </select>
+                    <input type="number" id="down-payment" min="10" max="50" step="0.01" required>
+                </div>
+                <div class="form-group">
+                    <label for="is-young-single">¿Eres joven soltero (menor de 35 años)?</label>
+                    <input type="checkbox" id="is-young-single">
+                </div>
+                <div class="form-group">
+                    <label for="uf-value">Valor actual de la UF (CLP):</label>
+                    <input type="number" id="uf-value" step="0.01" readonly>
+                </div>
+                <div class="form-group">
+                    <label for="interest-rate">Tasa de interés anual (%):</label>
+                    <input type="number" id="interest-rate" value="5.1" step="0.01" required>
+                </div>
+                <div class="form-group">
+                    <label for="loan-term">Plazo del crédito (años):</label>
+                    <select id="loan-term" required>
+                        <option value="10">10 años</option>
+                        <option value="15">15 años</option>
+                        <option value="20">20 años</option>
+                        <option value="25" selected>25 años</option>
+                        <option value="30">30 años</option>
+                    </select>
+                </div>
+                <button type="submit">Calcular</button>
+            </form>
+        </section>
+        <section id="results" class="results-container"></section>
+    </main>
+    <footer>
+        <button onclick="window.location.href='../index.html'">Volver al inicio</button>
+        <p>© 2025 Simulador de Subsidios para Vivienda</p>
+    </footer>
+    <script src="../assets/js/no-subsidy.js"></script>
+</body>
+</html>

--- a/simulator/templates/pages/percentile.html
+++ b/simulator/templates/pages/percentile.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Calcula subsidios según tu sueldo y situación familiar">
+    <title>Subsidios según tu sueldo - Simulador</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../assets/css/subsidies.css">
+</head>
+<body>
+    <header>
+        <h1>Subsidios de Compra de Vivienda según tu sueldo</h1>
+    </header>
+    <main>
+        <section class="form-container">
+            <form id="subsidy-form">
+                <div class="form-group">
+                    <label for="total-income">Sueldo mensual total (CLP):</label>
+                    <input type="number" id="total-income" min="0" required>
+                </div>
+                <div class="form-group">
+                    <label for="household-size">Número de personas en el hogar:</label>
+                    <input type="number" id="household-size" min="1" required>
+                </div>
+                <div class="form-group">
+                    <label for="rent">Arriendo mensual (CLP):</label>
+                    <input type="number" id="rent" min="0" required>
+                </div>
+                <button type="submit">Calcular</button>
+            </form>
+        </section>
+        <section id="results" class="results-container"></section>
+    </main>
+    <footer>
+        <button onclick="window.location.href='../index.html'">Volver al inicio</button>
+    </footer>
+    <script src="../assets/js/subsidies.js"></script>
+</body>
+</html>

--- a/simulator/templates/pages/percentile/ds1t1.html
+++ b/simulator/templates/pages/percentile/ds1t1.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Calcula el subsidio DS1 Tramo 1 para vivienda">
+    <title>Subsidio DS1 Tramo 1 - Simulador</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/subsidies.css">
+</head>
+<body>
+    <header>
+        <h1>Subsidio DS1 Tramo 1</h1>
+        <p>Ingresa tu ahorro y configura tu crédito para calcular el subsidio</p>
+    </header>
+    <main>
+        <section class="form-container">
+            <form id="ds1t1-form">
+                <div class="form-group">
+                    <label>Sueldo mensual total (CLP):</label>
+                    <p id="income-display">Cargando desde tu perfil...</p>
+                </div>
+                <div class="form-group">
+                    <label for="savings-uf">Ahorro en UF (mínimo 30 UF):</label>
+                    <input type="number" id="savings-uf" min="30" step="1" required>
+                </div>
+                <div class="form-group">
+                    <label for="location">Ubicación:</label>
+                    <select id="location" required>
+                        <option value="none">Zona Regular</option>
+                        <option value="north">Extremo Norte</option>
+                        <option value="south">Extremo Sur</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="loan-term">Plazo del crédito (años):</label>
+                    <select id="loan-term" required>
+                        <option value="10">10 años</option>
+                        <option value="15">15 años</option>
+                        <option value="20">20 años</option>
+                        <option value="25" selected>25 años</option>
+                        <option value="30">30 años</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="interest-rate">Tasa de interés anual (%):</label>
+                    <input type="number" id="interest-rate" value="5.1" step="0.01" required>
+                </div>
+                <div class="form-group">
+                    <label for="uf-value">Valor actual de la UF (CLP):</label>
+                    <input type="number" id="uf-value" step="0.01" readonly>
+                </div>
+                <button type="submit">Calcular</button>
+            </form>
+        </section>
+        <section id="results" class="results-container"></section>
+    </main>
+    <footer>
+        <button onclick="window.location.href='../percentile.html'">Volver</button>
+    </footer>
+    <script src="../../assets/js/percentile/ds1t1.js"></script>
+</body>
+</html>

--- a/simulator/templates/pages/percentile/ds1t2.html
+++ b/simulator/templates/pages/percentile/ds1t2.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Calcula el subsidio DS1 Tramo 2 para vivienda">
+    <title>Subsidio DS1 Tramo 2 - Simulador</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/subsidies.css">
+</head>
+<body>
+    <header>
+        <h1>Subsidio DS1 Tramo 2</h1>
+        <p>Configura tu ahorro y crédito para calcular el subsidio</p>
+    </header>
+    <main>
+        <section class="form-container">
+            <form id="ds1t2-form">
+                <div class="form-group">
+                    <label>Sueldo mensual total (CLP):</label>
+                    <p id="income-display">Cargando desde tu perfil...</p>
+                </div>
+                <div class="form-group">
+                    <label for="savings-uf">Ahorro en UF (mínimo 40 UF):</label>
+                    <input type="number" id="savings-uf" min="40" step="1" required>
+                </div>
+                <div class="form-group">
+                    <label for="is-young-single">¿Eres joven soltero (menor de 35 años)?</label>
+                    <input type="checkbox" id="is-young-single">
+                </div>
+                <div class="form-group">
+                    <label for="is-new-home">¿La vivienda es nueva?</label>
+                    <input type="checkbox" id="is-new-home">
+                </div>
+                <div class="form-group">
+                    <label for="location">Ubicación:</label>
+                    <select id="location" required>
+                        <option value="none">Zona Regular</option>
+                        <option value="north">Extremo Norte</option>
+                        <option value="south">Extremo Sur</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="loan-term">Plazo del crédito (años):</label>
+                    <select id="loan-term" required>
+                        <option value="10">10 años</option>
+                        <option value="15">15 años</option>
+                        <option value="20">20 años</option>
+                        <option value="25" selected>25 años</option>
+                        <option value="30">30 años</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="interest-rate">Tasa de interés anual (%):</label>
+                    <input type="number" id="interest-rate" value="5.1" step="0.01" required>
+                </div>
+                <div class="form-group">
+                    <label for="uf-value">Valor actual de la UF (CLP):</label>
+                    <input type="number" id="uf-value" step="0.01" readonly>
+                </div>
+                <button type="submit">Calcular</button>
+            </form>
+        </section>
+        <section id="results" class="results-container"></section>
+    </main>
+    <footer>
+        <button onclick="window.location.href='../percentile.html'">Volver</button>
+    </footer>
+    <script src="../../assets/js/percentile/ds1t2.js"></script>
+</body>
+</html>

--- a/simulator/templates/pages/percentile/ds1t3.html
+++ b/simulator/templates/pages/percentile/ds1t3.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Calcula el subsidio DS1 Tramo 3 para vivienda">
+    <title>Subsidio DS1 Tramo 3 - Simulador</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/subsidies.css">
+</head>
+<body>
+    <header>
+        <h1>Subsidio DS1 Tramo 3</h1>
+        <p>Configura tu ahorro y crédito para calcular el subsidio</p>
+    </header>
+    <main>
+        <section class="form-container">
+            <form id="ds1t3-form">
+                <div class="form-group">
+                    <label>Sueldo mensual total (CLP):</label>
+                    <p id="income-display">Cargando desde tu perfil...</p>
+                </div>
+                <div class="form-group">
+                    <label for="savings-uf">Ahorro en UF (mínimo 80 UF):</label>
+                    <input type="number" id="savings-uf" min="80" step="1" required>
+                </div>
+                <div class="form-group">
+                    <label for="is-young-single">¿Eres joven soltero (menor de 35 años)?</label>
+                    <input type="checkbox" id="is-young-single">
+                </div>
+                <div class="form-group">
+                    <label for="is-new-home">¿La vivienda es nueva?</label>
+                    <input type="checkbox" id="is-new-home">
+                </div>
+                <div class="form-group">
+                    <label for="location">Ubicación:</label>
+                    <select id="location" required>
+                        <option value="none">Zona Regular</option>
+                        <option value="north">Extremo Norte</option>
+                        <option value="south">Extremo Sur</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="loan-term">Plazo del crédito (años):</label>
+                    <select id="loan-term" required>
+                        <option value="10">10 años</option>
+                        <option value="15">15 años</option>
+                        <option value="20">20 años</option>
+                        <option value="25" selected>25 años</option>
+                        <option value="30">30 años</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="interest-rate">Tasa de interés anual (%):</label>
+                    <input type="number" id="interest-rate" value="5.1" step="0.01" required>
+                </div>
+                <div class="form-group">
+                    <label for="uf-value">Valor actual de la UF (CLP):</label>
+                    <input type="number" id="uf-value" step="0.01" readonly>
+                </div>
+                <button type="submit">Calcular</button>
+            </form>
+        </section>
+        <section id="results" class="results-container"></section>
+    </main>
+    <footer>
+        <button onclick="window.location.href='../percentile.html'">Volver</button>
+    </footer>
+    <script src="../../assets/js/percentile/ds1t3.js"></script>
+</body>
+</html>

--- a/simulator/templates/pages/percentile/ds49.html
+++ b/simulator/templates/pages/percentile/ds49.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Calcula el subsidio DS49 para vivienda según tu ahorro">
+    <title>Subsidio DS49 - Simulador</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/subsidies.css">
+</head>
+<body>
+    <header>
+        <h1>Subsidio DS49</h1>
+        <p>Ingresa tu ahorro en UF (mínimo 10 UF) y selecciona el tipo de zona</p>
+    </header>
+    <main>
+        <section class="form-container">
+            <form id="ds49-form">
+                <div class="form-group">
+                    <label for="savings-uf">Ahorro en UF (10 a 60 UF):</label>
+                    <input type="number" id="savings-uf" min="10" max="60" step="1" required>
+                </div>
+                <div class="form-group">
+                    <label for="zone-type">Tipo de zona:</label>
+                    <select id="zone-type" required>
+                        <option value="rural">Rural</option>
+                        <option value="urban">Urbana</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="uf-value">Valor actual de la UF (CLP):</label>
+                    <input type="number" id="uf-value" step="0.01" readonly>
+                </div>
+                <button type="submit">Calcular subsidio</button>
+            </form>
+        </section>
+        <section id="results" class="results-container"></section>
+    </main>
+    <footer>
+        <button onclick="window.location.href='../percentile.html'">Volver</button>
+    </footer>
+    <script src="../../assets/js/percentile/ds49.js"></script>
+</body>
+</html>

--- a/simulator/templates/pages/subsidies.html
+++ b/simulator/templates/pages/subsidies.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Elige un subsidio para simular tu compra de vivienda">
+    <title>Simulador de Subsidios - Opciones</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../assets/css/subsidies.css">
+</head>
+<body>
+    <header>
+        <h1>Simulador de Subsidios para Vivienda</h1>
+        <p>Selecciona un subsidio para iniciar la simulación</p>
+    </header>
+    <main>
+        <section class="subsidy-options">
+            <article class="subsidy-card">
+                <a href="subsidies/ds49.html">
+                    <h2>Subsidio DS49</h2>
+                    <p>Para personas en el 40% más vulnerable.</p>
+                </a>
+            </article>
+            <article class="subsidy-card">
+                <a href="subsidies/ds1t1.html">
+                    <h2>Subsidio DS1 Tramo 1</h2>
+                    <p>Para personas en el 60% más vulnerable.</p>
+                </a>
+            </article>
+            <article class="subsidy-card">
+                <a href="subsidies/ds1t2.html">
+                    <h2>Subsidio DS1 Tramo 2</h2>
+                    <p>Compra de viviendas hasta 1.600 UF (hasta 70% de vulnerabilidad).</p>
+                </a>
+            </article>
+            <article class="subsidy-card">
+                <a href="subsidies/ds1t3.html">
+                    <h2>Subsidio DS1 Tramo 3</h2>
+                    <p>Compra de viviendas hasta 2.200 UF.</p>
+                </a>
+            </article>
+            <article class="subsidy-card">
+                <a href="subsidies/ds19.html">
+                    <h2>Subsidio DS19</h2>
+                    <p>Simulación basada en crédito hipotecario ofrecido por inmobiliarias.</p>
+                </a>
+            </article>
+        </section>
+    </main>
+    <footer>
+        <button onclick="window.location.href='../index.html'">Volver al inicio</button>
+        <p>© 2025 Simulador de Subsidios para Vivienda</p>
+    </footer>
+</body>
+</html>

--- a/simulator/templates/pages/subsidies/ds19.html
+++ b/simulator/templates/pages/subsidies/ds19.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Calcula el dividendo y renta mínima para el Subsidio DS19">
+    <title>Subsidio DS19 - Simulador Directo</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/subsidies-alt.css">
+</head>
+<body>
+    <header>
+        <h1>Subsidio DS19</h1>
+        <p>Ingresa los datos del crédito hipotecario para calcular el dividendo</p>
+    </header>
+    <main>
+        <section class="form-container">
+            <form id="ds19-form">
+                <div class="form-group">
+                    <label for="loan-amount">Monto del crédito hipotecario (UF):</label>
+                    <input type="number" id="loan-amount" min="1" step="0.01" required>
+                </div>
+                <div class="form-group">
+                    <label for="is-young-single">¿Eres joven soltero (menor de 35 años)?</label>
+                    <input type="checkbox" id="is-young-single">
+                </div>
+                <div class="form-group">
+                    <label for="interest-rate">Tasa de interés anual (%):</label>
+                    <input type="number" id="interest-rate" value="5.1" step="0.01" required>
+                </div>
+                <div class="form-group">
+                    <label for="loan-term">Plazo del crédito (años):</label>
+                    <select id="loan-term" required>
+                        <option value="10">10 años</option>
+                        <option value="15">15 años</option>
+                        <option value="20">20 años</option>
+                        <option value="25" selected>25 años</option>
+                        <option value="30">30 años</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="uf-value">Valor actual de la UF (CLP):</label>
+                    <input type="number" id="uf-value" step="0.01" readonly>
+                </div>
+                <button type="submit">Calcular dividendo y renta mínima</button>
+            </form>
+        </section>
+        <section id="results" class="results-container"></section>
+    </main>
+    <footer>
+        <button onclick="window.location.href='../subsidies.html'">Volver</button>
+        <p>© 2025 Simulador de Subsidios para Vivienda</p>
+    </footer>
+    <script src="../../assets/js/subsidies/ds19.js"></script>
+</body>
+</html>

--- a/simulator/templates/pages/subsidies/ds1t1.html
+++ b/simulator/templates/pages/subsidies/ds1t1.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Calcula el crédito hipotecario para el Subsidio DS1 Tramo 1">
+    <title>Subsidio DS1 Tramo 1 - Simulador Directo</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/subsidies-alt.css">
+</head>
+<body>
+    <header>
+        <h1>Subsidio DS1 Tramo 1</h1>
+        <p>Ingresa los datos para calcular tu crédito hipotecario</p>
+    </header>
+    <main>
+        <section class="form-container">
+            <form id="ds1t1-form">
+                <div class="form-group">
+                    <label for="property-value-clp">Valor de la vivienda (CLP):</label>
+                    <input type="number" id="property-value-clp" min="0" step="1000" onchange="convertToUF()">
+                </div>
+                <div class="form-group">
+                    <label for="property-value">Valor de la vivienda (UF):</label>
+                    <input type="number" id="property-value" required step="0.01">
+                </div>
+                <div class="form-group">
+                    <label for="savings-uf">Ahorro en UF (mínimo 30 UF):</label>
+                    <input type="number" id="savings-uf" min="30" step="1" required>
+                </div>
+                <div class="form-group">
+                    <label for="uf-value">Valor actual de la UF (CLP):</label>
+                    <input type="number" id="uf-value" step="0.01" readonly>
+                </div>
+                <div class="form-group">
+                    <label for="interest-rate">Tasa de interés anual (%):</label>
+                    <input type="number" id="interest-rate" value="5.1" step="0.01" required>
+                </div>
+                <div class="form-group">
+                    <label for="location">Ubicación:</label>
+                    <select id="location" required>
+                        <option value="none">Zona Regular</option>
+                        <option value="north">Extremo Norte</option>
+                        <option value="south">Extremo Sur</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="loan-term">Plazo del crédito (años):</label>
+                    <select id="loan-term" required>
+                        <option value="10">10 años</option>
+                        <option value="15">15 años</option>
+                        <option value="20">20 años</option>
+                        <option value="25" selected>25 años</option>
+                        <option value="30">30 años</option>
+                    </select>
+                </div>
+                <button type="submit">Calcular crédito hipotecario</button>
+            </form>
+        </section>
+        <section id="results" class="results-container"></section>
+    </main>
+    <footer>
+        <button onclick="window.location.href='../subsidies.html'">Volver</button>
+        <p>© 2025 Simulador de Subsidios para Vivienda</p>
+    </footer>
+    <script src="../../assets/js/subsidies/ds1t1.js"></script>
+</body>
+</html>

--- a/simulator/templates/pages/subsidies/ds1t2.html
+++ b/simulator/templates/pages/subsidies/ds1t2.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Calcula el crédito hipotecario para el Subsidio DS1 Tramo 2">
+    <title>Subsidio DS1 Tramo 2 - Simulador Directo</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/subsidies-alt.css">
+</head>
+<body>
+    <header>
+        <h1>Subsidio DS1 Tramo 2</h1>
+        <p>Ingresa los datos para calcular tu crédito hipotecario</p>
+    </header>
+    <main>
+        <section class="form-container">
+            <form id="ds1t2-form">
+                <div class="form-group">
+                    <label for="property-value-clp">Valor de la vivienda (CLP):</label>
+                    <input type="number" id="property-value-clp" min="0" step="1000" onchange="convertToUF()">
+                </div>
+                <div class="form-group">
+                    <label for="property-value">Valor de la vivienda (UF):</label>
+                    <input type="number" id="property-value" min="600" required step="0.01">
+                </div>
+                <div class="form-group">
+                    <label for="savings-uf">Ahorro en UF (mínimo 40 UF):</label>
+                    <input type="number" id="savings-uf" min="40" step="1" onchange="adjustMaxPropertyValue()" required>
+                </div>
+                <div class="form-group">
+                    <label for="is-young-single">¿Eres joven soltero (menor de 35 años)?</label>
+                    <input type="checkbox" id="is-young-single">
+                </div>
+                <div class="form-group">
+                    <label for="is-new-home">¿La vivienda es nueva?</label>
+                    <input type="checkbox" id="is-new-home" onchange="adjustMaxPropertyValue()">
+                </div>
+                <div class="form-group">
+                    <label for="location">Ubicación:</label>
+                    <select id="location" onchange="adjustMaxPropertyValue()" required>
+                        <option value="none">Zona Regular</option>
+                        <option value="north">Extremo Norte</option>
+                        <option value="south">Extremo Sur</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="uf-value">Valor actual de la UF (CLP):</label>
+                    <input type="number" id="uf-value" step="0.01" readonly>
+                </div>
+                <div class="form-group">
+                    <label for="interest-rate">Tasa de interés anual (%):</label>
+                    <input type="number" id="interest-rate" value="5.1" step="0.01" required>
+                </div>
+                <div class="form-group">
+                    <label for="loan-term">Plazo del crédito (años):</label>
+                    <select id="loan-term" required>
+                        <option value="10">10 años</option>
+                        <option value="15">15 años</option>
+                        <option value="20">20 años</option>
+                        <option value="25" selected>25 años</option>
+                        <option value="30">30 años</option>
+                    </select>
+                </div>
+                <button type="submit">Calcular crédito hipotecario</button>
+            </form>
+        </section>
+        <section id="results" class="results-container"></section>
+    </main>
+    <footer>
+        <button onclick="window.location.href='../subsidies.html'">Volver</button>
+        <p>© 2025 Simulador de Subsidios para Vivienda</p>
+    </footer>
+    <script src="../../assets/js/subsidies/ds1t2.js"></script>
+</body>
+</html>

--- a/simulator/templates/pages/subsidies/ds1t3.html
+++ b/simulator/templates/pages/subsidies/ds1t3.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Calcula el crédito hipotecario para el Subsidio DS1 Tramo 3">
+    <title>Subsidio DS1 Tramo 3 - Simulador Directo</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/subsidies-alt.css">
+</head>
+<body>
+    <header>
+        <h1>Subsidio DS1 Tramo 3</h1>
+        <p>Ingresa los datos para calcular tu crédito hipotecario</p>
+    </header>
+    <main>
+        <section class="form-container">
+            <form id="ds1t3-form">
+                <div class="form-group">
+                    <label for="property-value-clp">Valor de la vivienda (CLP):</label>
+                    <input type="number" id="property-value-clp" min="0" step="1000" onchange="convertToUF()">
+                </div>
+                <div class="form-group">
+                    <label for="property-value">Valor de la vivienda (UF):</label>
+                    <input type="number" id="property-value" min="800" required step="0.01">
+                </div>
+                <div class="form-group">
+                    <label for="savings-uf">Ahorro en UF (mínimo 80 UF):</label>
+                    <input type="number" id="savings-uf" min="80" step="1" onchange="adjustMaxPropertyValue()" required>
+                </div>
+                <div class="form-group">
+                    <label for="is-young-single">¿Eres joven soltero (menor de 35 años)?</label>
+                    <input type="checkbox" id="is-young-single">
+                </div>
+                <div class="form-group">
+                    <label for="is-new-home">¿La vivienda es nueva?</label>
+                    <input type="checkbox" id="is-new-home" onchange="adjustMaxPropertyValue()">
+                </div>
+                <div class="form-group">
+                    <label for="location">Ubicación:</label>
+                    <select id="location" onchange="adjustMaxPropertyValue()" required>
+                        <option value="none">Zona Regular</option>
+                        <option value="north">Extremo Norte</option>
+                        <option value="south">Extremo Sur</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="uf-value">Valor actual de la UF (CLP):</label>
+                    <input type="number" id="uf-value" step="0.01" readonly>
+                </div>
+                <div class="form-group">
+                    <label for="interest-rate">Tasa de interés anual (%):</label>
+                    <input type="number" id="interest-rate" value="5.1" step="0.01" required>
+                </div>
+                <div class="form-group">
+                    <label for="loan-term">Plazo del crédito (años):</label>
+                    <select id="loan-term" required>
+                        <option value="10">10 años</option>
+                        <option value="15">15 años</option>
+                        <option value="20">20 años</option>
+                        <option value="25" selected>25 años</option>
+                        <option value="30">30 años</option>
+                    </select>
+                </div>
+                <button type="submit">Calcular crédito hipotecario</button>
+            </form>
+        </section>
+        <section id="results" class="results-container"></section>
+    </main>
+    <footer>
+        <button onclick="window.location.href='../subsidies.html'">Volver</button>
+        <p>© 2025 Simulador de Subsidios para Vivienda</p>
+    </footer>
+    <script src="../../assets/js/subsidies/ds1t3.js"></script>
+</body>
+</html>

--- a/simulator/templates/pages/subsidies/ds49.html
+++ b/simulator/templates/pages/subsidies/ds49.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Calcula el subsidio DS49 para vivienda según tu ahorro">
+    <title>Subsidio DS49 - Simulador</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/subsidies-alt.css">
+</head>
+<body>
+    <header>
+        <h1>Subsidio DS49</h1>
+        <p>Ingresa tu ahorro en UF (mínimo 10 UF) y selecciona el tipo de zona</p>
+    </header>
+    <main>
+        <section class="form-container">
+            <form id="ds49-form">
+                <div class="form-group">
+                    <label for="savings-uf">Ahorro en UF (10 a 60 UF):</label>
+                    <input type="number" id="savings-uf" min="10" max="60" step="1" required>
+                </div>
+                <div class="form-group">
+                    <label for="zone-type">Tipo de zona:</label>
+                    <select id="zone-type" required>
+                        <option value="rural">Rural</option>
+                        <option value="urban">Urbana</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="uf-value">Valor actual de la UF (CLP):</label>
+                    <input type="number" id="uf-value" step="0.01" readonly>
+                </div>
+                <button type="submit">Calcular subsidio</button>
+            </form>
+        </section>
+        <section id="results" class="results-container"></section>
+    </main>
+    <footer>
+        <button onclick="window.location.href='../subsidies.html'">Volver</button>
+    </footer>
+    <script src="../../assets/js/percentile/ds49.js"></script>
+</body>
+</html>

--- a/simulator/templates/pages/subsidy-assistant.html
+++ b/simulator/templates/pages/subsidy-assistant.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Asistente interactivo para determinar a qué subsidios habitacionales puedes optar">
+    <title>Asistente de Subsidios - Simulador</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../assets/css/subsidy-assistant.css">
+</head>
+<body>
+    <header>
+        <h1>Asistente de Subsidios</h1>
+        <p>Responde las preguntas para descubrir a qué subsidios puedes optar</p>
+    </header>
+    <main>
+        <section id="question-container" class="question-container">
+            <h2 id="question-text">Cargando...</h2>
+            <div id="options" class="options">
+                <!-- Los botones se generarán dinámicamente -->
+            </div>
+        </section>
+        <section id="result" class="result-container" style="display: none;">
+            <h2>Resultado</h2>
+            <p id="result-text"></p>
+            <button id="restart" onclick="restartAssistant()">Volver a empezar</button>
+        </section>
+    </main>
+    <footer>
+        <button onclick="window.location.href='../index.html'">Volver al inicio</button>
+        <p>© 2025 Simulador de Subsidios para Vivienda</p>
+    </footer>
+    <script src="../assets/js/subsidy-assistant.js"></script>
+</body>
+</html>

--- a/simulator/web/urls.py
+++ b/simulator/web/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from .views import HomeView
+
+urlpatterns = [
+    path('', HomeView.as_view(), name='home'),
+]

--- a/simulator/web/views.py
+++ b/simulator/web/views.py
@@ -1,0 +1,4 @@
+from django.views.generic import TemplateView
+
+class HomeView(TemplateView):
+    template_name = 'Index.html'


### PR DESCRIPTION
## Summary
- set up a minimal Django project under `simulator/`
- copy existing HTML pages into Django templates
- expose root page via a simple view

## Testing
- `python3 simulator/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6862d4d50f3c8320a6b3488ce1f57740